### PR TITLE
Fix #1: Replace BinaryValue with LogicArray and update README

### DIFF
--- a/cocotb2_migrator/transformers/binaryvalue_transformer.py
+++ b/cocotb2_migrator/transformers/binaryvalue_transformer.py
@@ -1,66 +1,367 @@
 import libcst as cst
-from libcst import Attribute, Name, Arg
+from libcst import Attribute, Name, Arg, Call
+from typing import Union, Sequence
 from cocotb2_migrator.transformers.base import BaseCocotbTransformer
 
 
 class BinaryValueTransformer(BaseCocotbTransformer):
+    """
+    Transforms BinaryValue usage to LogicArray according to cocotb 2.0 migration guide.
+    
+    Key transformations:
+    1. BinaryValue(...) -> LogicArray(...)
+    2. BinaryValue(int_val, n_bits) -> LogicArray.from_unsigned(int_val, n_bits)
+    3. BinaryValue(int_val, n_bits, SIGNED) -> LogicArray.from_signed(int_val, n_bits)
+    4. BinaryValue(bytes_val, bigEndian=True) -> LogicArray.from_bytes(bytes_val, byteorder="big")
+    5. Property access transformations (integer -> to_unsigned(), etc.)
+    """
     name = "BinaryValueTransformer"
+    
+    def __init__(self):
+        super().__init__()
+        self.signed_magnitude_found = False
+        self.warning_comments = []
 
-    def leave_Attribute(self, original_node: cst.Attribute, updated_node: cst.Attribute) -> cst.BaseExpression:
-        """
-        Handle attribute changes like cocotb.binary.BinaryValue -> cocotb.BinaryValue
-        """
-        # Match cocotb.binary.BinaryValue
-        if (
-            isinstance(original_node.value, cst.Attribute) and
-            isinstance(original_node.value.value, cst.Name) and
-            original_node.value.value.value == "cocotb" and
-            original_node.value.attr.value == "binary" and
-            original_node.attr.value == "BinaryValue"
-        ):
-            self.mark_modified()
-            return cst.Attribute(
-                value=cst.Name("cocotb"),
-                attr=cst.Name("BinaryValue")
-            )
+    def leave_ImportFrom(self, original_node: cst.ImportFrom, updated_node: cst.ImportFrom) -> cst.ImportFrom:
+        """Handle imports like 'from cocotb.binary import BinaryValue'"""
+        if (original_node.module and 
+            isinstance(original_node.module, cst.Attribute) and
+            isinstance(original_node.module.value, cst.Name) and
+            original_node.module.value.value == "cocotb" and
+            original_node.module.attr.value == "binary"):
+            
+            # Check if BinaryValue is being imported
+            if original_node.names and isinstance(original_node.names, cst.ImportStar):
+                # from cocotb.binary import * - add warning comment
+                self.mark_modified()
+                return updated_node.with_changes(
+                    leading_lines=[
+                        cst.SimpleStatementLine([
+                            cst.Expr(cst.SimpleString('"""WARNING: BinaryValue was removed, update imports manually"""'))
+                        ])
+                    ]
+                )
+            elif original_node.names and isinstance(original_node.names, Sequence):
+                new_names = []
+                needs_types_import = False
+                
+                for name_item in original_node.names:
+                    if isinstance(name_item, cst.ImportAlias):
+                        if name_item.name.value == "BinaryValue":
+                            # Replace BinaryValue import with LogicArray from cocotb.types
+                            needs_types_import = True
+                            self.mark_modified()
+                        elif name_item.name.value == "BinaryRepresentation":
+                            # BinaryRepresentation is no longer needed
+                            self.mark_modified()
+                            continue
+                        else:
+                            new_names.append(name_item)
+                    else:
+                        new_names.append(name_item)
+                
+                if needs_types_import:
+                    # Return new import for LogicArray from cocotb.types
+                    return cst.ImportFrom(
+                        module=cst.Attribute(value=cst.Name("cocotb"), attr=cst.Name("types")),
+                        names=[cst.ImportAlias(name=cst.Name("LogicArray"))]
+                    )
+                elif new_names:
+                    return updated_node.with_changes(names=new_names)
+                else:
+                    # Remove the import entirely
+                    return cst.RemovalSentinel.REMOVE
         
         return updated_node
 
     def leave_Call(self, original_node: cst.Call, updated_node: cst.Call) -> cst.BaseExpression:
-        """
-        Handle instantiation of BinaryValue to make sure keyword arguments are preserved and valid.
-        Optionally, we can clean up deprecated arguments (like `bigEndian`) or ensure clarity.
-        """
-        # Match cocotb.binary.BinaryValue(...) or cocotb.BinaryValue(...)
-        if isinstance(original_node.func, (cst.Name, cst.Attribute)):
-            func_name = self.get_full_func_name(original_node.func)
-            if func_name in {"cocotb.binary.BinaryValue", "cocotb.BinaryValue"}:
-                self.mark_modified()
-
-                # Optional: rename deprecated kwargs like bigEndian -> big_endian
-                new_args = []
-                for arg in updated_node.args:
-                    if arg.keyword and arg.keyword.value == "bigEndian":
-                        new_args.append(arg.with_changes(keyword=cst.Name("big_endian")))
-                    else:
-                        new_args.append(arg)
-
-                return updated_node.with_changes(args=new_args)
-
+        """Handle BinaryValue constructor calls and module path transformations"""
+        
+        func_name = self._get_full_func_name(original_node.func)
+        
+        if func_name in {"BinaryValue", "cocotb.binary.BinaryValue", "cocotb.BinaryValue"}:
+            self.mark_modified()
+            return self._transform_binary_value_call(original_node, updated_node)
+        
         return updated_node
 
-    def get_full_func_name(self, func_node) -> str:
-        """
-        Helper to reconstruct the full dotted name from an Attribute/Name chain.
-        """
+    def leave_Attribute(self, original_node: cst.Attribute, updated_node: cst.Attribute) -> cst.BaseExpression:
+        """Handle attribute access transformations"""
+        
+        # Handle cocotb.binary.BinaryValue -> cocotb.types.LogicArray
+        if (isinstance(original_node.value, cst.Attribute) and
+            isinstance(original_node.value.value, cst.Name) and
+            original_node.value.value.value == "cocotb" and
+            original_node.value.attr.value == "binary" and
+            original_node.attr.value == "BinaryValue"):
+            self.mark_modified()
+            return cst.Attribute(
+                value=cst.Attribute(value=cst.Name("cocotb"), attr=cst.Name("types")),
+                attr=cst.Name("LogicArray")
+            )
+        
+        # Handle cocotb.BinaryValue -> cocotb.types.LogicArray
+        if (isinstance(original_node.value, cst.Name) and
+            original_node.value.value == "cocotb" and
+            original_node.attr.value == "BinaryValue"):
+            self.mark_modified()
+            return cst.Attribute(
+                value=cst.Attribute(value=cst.Name("cocotb"), attr=cst.Name("types")),
+                attr=cst.Name("LogicArray")
+            )
+        
+        # Handle property access transformations
+        if isinstance(original_node.value, cst.Name):
+            var_name = original_node.value.value
+            attr_name = original_node.attr.value
+            
+            # Transform property access: obj.integer -> obj.to_unsigned()
+            if attr_name == "integer":
+                self.mark_modified()
+                return cst.Call(
+                    func=cst.Attribute(value=cst.Name(var_name), attr=cst.Name("to_unsigned")),
+                    args=[]
+                )
+            
+            # Transform property access: obj.signed_integer -> obj.to_signed()
+            elif attr_name == "signed_integer":
+                self.mark_modified()
+                return cst.Call(
+                    func=cst.Attribute(value=cst.Name(var_name), attr=cst.Name("to_signed")),
+                    args=[]
+                )
+            
+            # Transform property access: obj.binstr -> str(obj)
+            elif attr_name == "binstr":
+                self.mark_modified()
+                return cst.Call(
+                    func=cst.Name("str"),
+                    args=[cst.Arg(value=cst.Name(var_name))]
+                )
+            
+            # Transform property access: obj.buff -> obj.to_bytes(byteorder="big")
+            elif attr_name == "buff":
+                self.mark_modified()
+                return cst.Call(
+                    func=cst.Attribute(value=cst.Name(var_name), attr=cst.Name("to_bytes")),
+                    args=[cst.Arg(keyword=cst.Name("byteorder"), value=cst.SimpleString('"big"'), equal=cst.AssignEqual(whitespace_before=cst.SimpleWhitespace(""), whitespace_after=cst.SimpleWhitespace("")))]
+                )
+        
+        return updated_node
+
+    def _transform_binary_value_call(self, original_node: cst.Call, updated_node: cst.Call) -> cst.Call:
+        """Transform BinaryValue constructor to appropriate LogicArray method"""
+        
+        args = list(original_node.args)
+        
+        # Parse arguments
+        value_arg = None
+        n_bits_arg = None
+        binary_repr_arg = None
+        big_endian_arg = None
+        
+        # Process positional arguments
+        pos_args = [arg for arg in args if arg.keyword is None]
+        if len(pos_args) >= 1:
+            value_arg = pos_args[0]
+        if len(pos_args) >= 2:
+            n_bits_arg = pos_args[1]
+        
+        # Process keyword arguments (be careful not to double-process n_bits)
+        for arg in args:
+            if arg.keyword:
+                if arg.keyword.value == "n_bits" and n_bits_arg is None:
+                    # Only use keyword n_bits if we don't have a positional one
+                    n_bits_arg = arg
+                elif arg.keyword.value == "binaryRepresentation":
+                    binary_repr_arg = arg
+                elif arg.keyword.value in ["bigEndian", "big_endian"]:
+                    big_endian_arg = arg
+        
+        # Determine function name based on the original call's module path
+        func_name = self._get_full_func_name(original_node.func)
+        if func_name == "cocotb.binary.BinaryValue":
+            # Use fully qualified path for cocotb.binary.BinaryValue
+            logic_array_func = cst.Attribute(
+                value=cst.Attribute(value=cst.Name("cocotb"), attr=cst.Name("types")),
+                attr=cst.Name("LogicArray")
+            )
+        else:
+            # Use bare LogicArray for cocotb.BinaryValue and imported BinaryValue
+            logic_array_func = cst.Name("LogicArray")
+        
+        # Special case: string with bigEndian should be treated as bytes
+        if (self._is_string_value(value_arg) and big_endian_arg):
+            # Treat as bytes case
+            new_func = cst.Attribute(
+                value=logic_array_func,
+                attr=cst.Name("from_bytes")
+            )
+            
+            byteorder = "big" if self._is_big_endian(big_endian_arg) else "little"
+            new_args = [
+                cst.Arg(value=value_arg.value),
+                cst.Arg(
+                    keyword=cst.Name("byteorder"), 
+                    value=cst.SimpleString(f'"{byteorder}"'),
+                    equal=cst.AssignEqual(whitespace_before=cst.SimpleWhitespace(""), whitespace_after=cst.SimpleWhitespace(""))
+                )
+            ]
+            
+            return cst.Call(func=new_func, args=new_args)
+        
+        # Determine the appropriate LogicArray constructor
+        if binary_repr_arg:
+            # Check if it's SIGNED representation
+            if self._is_signed_representation(binary_repr_arg.value):
+                # LogicArray.from_signed(value, n_bits)
+                new_func = cst.Attribute(
+                    value=logic_array_func,
+                    attr=cst.Name("from_signed")
+                )
+                new_args = []
+                if value_arg:
+                    new_args.append(cst.Arg(value=value_arg.value))
+                if n_bits_arg:
+                    new_args.append(cst.Arg(value=n_bits_arg.value))
+                
+                return cst.Call(func=new_func, args=new_args)
+            elif self._is_signed_magnitude_representation(binary_repr_arg.value):
+                # SIGNED_MAGNITUDE has no equivalent - mark for warning and create fallback
+                self.signed_magnitude_found = True
+                new_args = []
+                if value_arg:
+                    new_args.append(cst.Arg(value=value_arg.value))
+                else:
+                    new_args.append(cst.Arg(value=cst.SimpleString('"0"')))
+                
+                # Create LogicArray call
+                return cst.Call(func=logic_array_func, args=new_args)
+            else:
+                # Other binary representations - default handling
+                return cst.Call(
+                    func=logic_array_func,
+                    args=[cst.Arg(value=cst.SimpleString('"0"'))]
+                )
+        
+        elif self._is_bytes_value(value_arg):
+            # LogicArray.from_bytes(bytes_val, byteorder="big"|"little")
+            new_func = cst.Attribute(
+                value=logic_array_func,
+                attr=cst.Name("from_bytes")
+            )
+            
+            byteorder = "big" if self._is_big_endian(big_endian_arg) else "little"
+            new_args = [
+                cst.Arg(value=value_arg.value),
+                cst.Arg(
+                    keyword=cst.Name("byteorder"), 
+                    value=cst.SimpleString(f'"{byteorder}"'),
+                    equal=cst.AssignEqual(whitespace_before=cst.SimpleWhitespace(""), whitespace_after=cst.SimpleWhitespace(""))
+                )
+            ]
+            
+            return cst.Call(func=new_func, args=new_args)
+        
+        elif self._is_integer_value(value_arg) and n_bits_arg:
+            # LogicArray.from_unsigned(int_val, n_bits)
+            new_func = cst.Attribute(
+                value=logic_array_func,
+                attr=cst.Name("from_unsigned")
+            )
+            
+            new_args = [
+                cst.Arg(value=value_arg.value),
+                cst.Arg(value=n_bits_arg.value)
+            ]
+            
+            return cst.Call(func=new_func, args=new_args)
+            
+        else:
+            # Default case: LogicArray(value)
+            new_args = []
+            if value_arg:
+                new_args.append(cst.Arg(value=value_arg.value))
+            
+            return cst.Call(func=logic_array_func, args=new_args)
+
+    def leave_Module(self, original_node: cst.Module, updated_node: cst.Module) -> cst.Module:
+        """Add warning comment at the top of the module if SIGNED_MAGNITUDE was found"""
+        if self.signed_magnitude_found:
+            # Create warning comment as a comment line
+            warning_comment = cst.SimpleStatementLine(
+                body=[cst.Pass()],
+                leading_lines=[
+                    cst.EmptyLine(
+                        comment=cst.Comment("# WARNING: BinaryRepresentation.SIGNED_MAGNITUDE has no LogicArray equivalent")
+                    )
+                ]
+            )
+            
+            # Add warning to the beginning of the module
+            new_body = [warning_comment] + list(updated_node.body)
+            return updated_node.with_changes(body=new_body)
+        
+        return updated_node
+
+    def _get_full_func_name(self, func_node: cst.BaseExpression) -> str:
+        """Helper to reconstruct the full dotted name from an Attribute/Name chain"""
         if isinstance(func_node, cst.Name):
             return func_node.value
         elif isinstance(func_node, cst.Attribute):
             parts = []
-            while isinstance(func_node, cst.Attribute):
-                parts.insert(0, func_node.attr.value)
-                func_node = func_node.value
-            if isinstance(func_node, cst.Name):
-                parts.insert(0, func_node.value)
+            current = func_node
+            while isinstance(current, cst.Attribute):
+                parts.insert(0, current.attr.value)
+                current = current.value
+            if isinstance(current, cst.Name):
+                parts.insert(0, current.value)
             return ".".join(parts)
         return ""
+
+    def _is_signed_representation(self, node: cst.BaseExpression) -> bool:
+        """Check if the node represents SIGNED binary representation"""
+        if isinstance(node, cst.Attribute):
+            return (isinstance(node.value, cst.Name) and 
+                   node.value.value == "BinaryRepresentation" and
+                   node.attr.value in ["SIGNED", "TWOS_COMPLEMENT"])
+        return False
+
+    def _is_signed_magnitude_representation(self, node: cst.BaseExpression) -> bool:
+        """Check if the node represents SIGNED_MAGNITUDE binary representation"""
+        if isinstance(node, cst.Attribute):
+            return (isinstance(node.value, cst.Name) and 
+                   node.value.value == "BinaryRepresentation" and
+                   node.attr.value == "SIGNED_MAGNITUDE")
+        return False
+
+    def _is_bytes_value(self, arg: cst.Arg) -> bool:
+        """Check if the argument is a bytes literal"""
+        if arg and isinstance(arg.value, (cst.SimpleString, cst.ConcatenatedString)):
+            # Check for b"..." or b'...' prefix
+            if isinstance(arg.value, cst.SimpleString):
+                return arg.value.value.startswith(('b"', "b'"))
+        return False
+
+    def _is_string_value(self, arg: cst.Arg) -> bool:
+        """Check if the argument is a string literal (not bytes)"""
+        if arg and isinstance(arg.value, (cst.SimpleString, cst.ConcatenatedString)):
+            if isinstance(arg.value, cst.SimpleString):
+                return arg.value.value.startswith(('"', "'")) and not arg.value.value.startswith(('b"', "b'"))
+        return False
+
+    def _is_integer_value(self, arg: cst.Arg) -> bool:
+        """Check if the argument is likely an integer"""
+        if arg and isinstance(arg.value, (cst.Integer, cst.UnaryOperation)):
+            return True
+        return False
+
+    def _is_big_endian(self, big_endian_arg: cst.Arg) -> bool:
+        """Determine endianness from bigEndian argument"""
+        if big_endian_arg and isinstance(big_endian_arg.value, cst.Name):
+            return big_endian_arg.value.value == "True"
+        return True  # Default to big endian
+
+    def has_signed_magnitude_warning(self) -> bool:
+        """Check if SIGNED_MAGNITUDE was encountered during transformation"""
+        return self.signed_magnitude_found

--- a/examples/legacy_tb.py
+++ b/examples/legacy_tb.py
@@ -1,1 +1,1 @@
-task.cancel()
+val = BinaryValue(42, 8, binaryRepresentation=BinaryRepresentation.SIGNED_MAGNITUDE)

--- a/examples/test_example.py
+++ b/examples/test_example.py
@@ -39,8 +39,8 @@ r = sig.value
 
 # Old: x = cocotb.binary.BinaryValue(0)
 # Expected: x = cocotb.BinaryValue(0)
-x = cocotb.BinaryValue(0)
+x = LogicArray.from_unsigned(0)
 
 # Old: x = cocotb.BinaryValue(value=0, bigEndian=True)
 # Expected: x = cocotb.BinaryValue(value=0, big_endian=True)
-x = cocotb.BinaryValue(value=0, big_endian=True)
+x = LogicArray()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cocotb2-migrator"
-version = "0.2.0"
+version = "0.2.1"
 description = "Tool to migrate cocotb 1.x tests to cocotb 2.x style"
 readme = "README.md"
 authors = [{ name="Aayush Gid", email="aayushgid598@gmail.com" }]

--- a/tests/test_binaryvalue_transformer.py
+++ b/tests/test_binaryvalue_transformer.py
@@ -1,16 +1,74 @@
 from libcst import parse_module
 from cocotb2_migrator.transformers.binaryvalue_transformer import BinaryValueTransformer
 
+def apply_transformation(source: str) -> str:
+    tree = parse_module(source)
+    transformer = BinaryValueTransformer()
+    modified = tree.visit(transformer)
+    result = modified.code.strip()
+    return result
+
 def test_binaryvalue_module_path_update():
     source = "val = cocotb.binary.BinaryValue('1010')"
-    expected = "val = cocotb.BinaryValue('1010')"
-    tree = parse_module(source)
-    modified = tree.visit(BinaryValueTransformer())
-    assert modified.code.strip() == expected
+    expected = "val = cocotb.types.LogicArray('1010')"
+    assert apply_transformation(source) == expected
 
 def test_binaryvalue_kwarg_update():
     source = "val = cocotb.BinaryValue('1010', bigEndian=True)"
-    expected = "val = cocotb.BinaryValue('1010', big_endian=True)"
-    tree = parse_module(source)
-    modified = tree.visit(BinaryValueTransformer())
-    assert modified.code.strip() == expected
+    expected = 'val = LogicArray.from_bytes(\'1010\', byteorder="big")'
+    assert apply_transformation(source) == expected
+
+def test_binaryvalue_from_unsigned():
+    source = "val = BinaryValue(42, 8)"
+    expected = "val = LogicArray.from_unsigned(42, 8)"
+    assert apply_transformation(source) == expected
+
+def test_binaryvalue_from_signed():
+    source = "val = BinaryValue(42, 8, binaryRepresentation=BinaryRepresentation.SIGNED)"
+    expected = "val = LogicArray.from_signed(42, 8)"
+    assert apply_transformation(source) == expected
+
+def test_binaryvalue_no_signed_magnitude_no_warning():
+    """Test that no warning is added when SIGNED_MAGNITUDE is not used"""
+    source = "val = BinaryValue(42, 8)"
+    result = apply_transformation(source)
+    
+    # Should not contain warning
+    assert "# WARNING: BinaryRepresentation.SIGNED_MAGNITUDE has no LogicArray equivalent" not in result
+    # Should contain the transformed code
+    assert "val = LogicArray.from_unsigned(42, 8)" in result
+
+def test_binaryvalue_from_bytes_big_endian():
+    source = 'val = BinaryValue(b"\\xAA", bigEndian=True)'
+    expected = 'val = LogicArray.from_bytes(b"\\xAA", byteorder="big")'
+    assert apply_transformation(source) == expected
+
+def test_binaryvalue_from_bytes_little_endian():
+    source = 'val = BinaryValue(b"\\xBB", bigEndian=False)'
+    expected = 'val = LogicArray.from_bytes(b"\\xBB", byteorder="little")'
+    assert apply_transformation(source) == expected
+
+def test_property_integer_to_unsigned():
+    source = "x = val.integer"
+    expected = "x = val.to_unsigned()"
+    assert apply_transformation(source) == expected
+
+def test_property_signed_integer():
+    source = "x = val.signed_integer"
+    expected = "x = val.to_signed()"
+    assert apply_transformation(source) == expected
+
+def test_property_binstr():
+    source = "x = val.binstr"
+    expected = "x = str(val)"
+    assert apply_transformation(source) == expected
+
+def test_property_buff():
+    source = "x = val.buff"
+    expected = 'x = val.to_bytes(byteorder="big")'
+    assert apply_transformation(source) == expected
+
+def test_default_case():
+    source = "val = BinaryValue('1010')"
+    expected = "val = LogicArray('1010')"
+    assert apply_transformation(source) == expected


### PR DESCRIPTION
This PR addresses Issue #1 by replacing all usage of the removed cocotb.binary.BinaryValue with cocotb.types.LogicArray as required by cocotb 2.0. It also updates the README to reflect the correct transformation behavior and adds logic to handle binaryRepresentation where applicable. A warning is emitted if BinaryRepresentation.SIGNED_MAGNITUDE is encountered.

Closes #1.