### PR TITLE
Fix #4: Remove invalid get_value()/raw_value handle transformations

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,18 +107,14 @@ Modernizes signal value access patterns:
 
 **Before:**
 ```python
-val = dut.signal.value.get_value()
 integer_val = dut.signal.value.integer
 binary_str = dut.signal.value.binstr
-raw_val = dut.signal.value.raw_value
 ```
 
 **After:**
 ```python
-val = dut.signal.value
 integer_val = int(dut.signal.value)
 binary_str = format(dut.signal.value, 'b')
-raw_val = dut.signal.value
 ```
 
 ### 4. Binary Value Updates

--- a/cocotb2_migrator/transformers/handle_transformer.py
+++ b/cocotb2_migrator/transformers/handle_transformer.py
@@ -9,22 +9,15 @@ class HandleTransformer(BaseCocotbTransformer):
     def leave_Attribute(self, original_node: cst.Attribute, updated_node: cst.Attribute) -> cst.BaseExpression:
         """
         Update deprecated handle attributes, such as:
-        - handle.value.get_value() -> handle.value
-        - handle.value.integer    -> int(handle.value)
-        - handle.value.binstr     -> format(handle.value, 'b')
-        - handle.value.raw_value  -> handle.value
+        - handle.value.integer -> int(handle.value)
+        - handle.value.binstr  -> format(handle.value, 'b')
         """
         if isinstance(original_node.attr, cst.Name) and isinstance(original_node.value, cst.Attribute):
             base = original_node.value
             attr = original_node.attr.value
 
             if isinstance(base.attr, cst.Name) and base.attr.value == "value":
-                if attr == "get_value":
-                    # handle.value.get_value() -> handle.value
-                    self.mark_modified()
-                    return base
-
-                elif attr == "integer":
+                if attr == "integer":
                     # handle.value.integer -> int(handle.value)
                     self.mark_modified()
                     return cst.Call(
@@ -42,27 +35,5 @@ class HandleTransformer(BaseCocotbTransformer):
                             cst.Arg(value=cst.SimpleString("'b'"))
                         ]
                     )
-
-                elif attr == "raw_value":
-                    # handle.value.raw_value -> handle.value
-                    self.mark_modified()
-                    return base
-
-        return updated_node
-
-    def leave_Call(self, original_node: cst.Call, updated_node: cst.Call) -> cst.BaseExpression:
-        """
-        Remove .get_value() calls: handle.value.get_value() -> handle.value
-        """
-        if isinstance(original_node.func, cst.Attribute):
-            func_attr = original_node.func
-            if (
-                isinstance(func_attr.value, cst.Attribute) and
-                func_attr.attr.value == "get_value" and
-                isinstance(func_attr.value.attr, cst.Name) and
-                func_attr.value.attr.value == "value"
-            ):
-                self.mark_modified()
-                return func_attr.value
 
         return updated_node

--- a/examples/test_example.py
+++ b/examples/test_example.py
@@ -17,10 +17,6 @@ cocotb.start_soon(my_task())
 # Handle Transformations
 # ========================
 
-# Old: val = sig.value.get_value()
-# Expected: val = sig.value
-val = sig.value
-
 # Old: i = sig.value.integer
 # Expected: i = int(sig.value)
 i = int(sig.value)
@@ -28,10 +24,6 @@ i = int(sig.value)
 # Old: b = sig.value.binstr
 # Expected: b = format(sig.value, 'b')
 b = format(sig.value, 'b')
-
-# Old: r = sig.value.raw_value
-# Expected: r = sig.value
-r = sig.value
 
 # ========================
 # BinaryValue Transformation

--- a/tests/test_handle_transformer.py
+++ b/tests/test_handle_transformer.py
@@ -1,12 +1,6 @@
 from libcst import parse_module
 from cocotb2_migrator.transformers.handle_transformer import HandleTransformer
 
-def test_get_value_removed():
-    source = "val = sig.value.get_value()"
-    expected = "val = sig.value"
-    mod = parse_module(source).visit(HandleTransformer())
-    assert mod.code.strip() == expected
-
 def test_integer_to_int():
     source = "i = sig.value.integer"
     expected = "i = int(sig.value)"
@@ -19,8 +13,14 @@ def test_binstr_to_format():
     mod = parse_module(source).visit(HandleTransformer())
     assert mod.code.strip() == expected
 
-def test_raw_value_removed():
+def test_get_value_left_unchanged():
+    source = "val = sig.value.get_value()"
+    expected = "val = sig.value.get_value()"
+    mod = parse_module(source).visit(HandleTransformer())
+    assert mod.code.strip() == expected
+
+def test_raw_value_left_unchanged():
     source = "r = sig.value.raw_value"
-    expected = "r = sig.value"
+    expected = "r = sig.value.raw_value"
     mod = parse_module(source).visit(HandleTransformer())
     assert mod.code.strip() == expected


### PR DESCRIPTION
Fixes #4

`handle.get_value()` and `handle.raw_value` do not exist in cocotb. The
`HandleTransformer` was rewriting them (e.g. `sig.value.get_value()` ->
`sig.value`), which could silently corrupt legitimate user code that happens
to use those names.

These transformations have been removed entirely, so non-existent cocotb
APIs are now left untouched.

## Changes

- `cocotb2_migrator/transformers/handle_transformer.py`
  - Removed the `get_value` and `raw_value` transformation branches
  - Removed the now-unused `leave_Call` handler
- `tests/test_handle_transformer.py`
  - Removed obsolete `get_value`/`raw_value` tests
  - Added tests asserting these patterns are left unchanged
- `README.md` — removed `get_value()`/`raw_value` from the Handle Value Access docs
- `examples/test_example.py` — removed the corresponding example blocks

## Testing

- `pytest tests/test_handle_transformer.py` → 4 passed
- Full suite: 60 passed, 2 pre-existing failures in
  `test_clock_transformer.py` (unrelated, already failing on `main`)
- End-to-end run of the migrator confirmed `.integer`/`.binstr` are still
  migrated while `get_value()`/`raw_value` pass through unchanged