### PR TITLE
Fix #5: Prefer str(handle.value) over format(handle.value, 'b')

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ binary_str = dut.signal.value.binstr
 **After:**
 ```python
 integer_val = int(dut.signal.value)
-binary_str = format(dut.signal.value, 'b')
+binary_str = str(dut.signal.value)
 ```
 
 ### 4. Binary Value Updates

--- a/cocotb2_migrator/transformers/handle_transformer.py
+++ b/cocotb2_migrator/transformers/handle_transformer.py
@@ -10,7 +10,7 @@ class HandleTransformer(BaseCocotbTransformer):
         """
         Update deprecated handle attributes, such as:
         - handle.value.integer -> int(handle.value)
-        - handle.value.binstr  -> format(handle.value, 'b')
+        - handle.value.binstr  -> str(handle.value)
         """
         if isinstance(original_node.attr, cst.Name) and isinstance(original_node.value, cst.Attribute):
             base = original_node.value
@@ -26,14 +26,11 @@ class HandleTransformer(BaseCocotbTransformer):
                     )
 
                 elif attr == "binstr":
-                    # handle.value.binstr -> format(handle.value, 'b')
+                    # handle.value.binstr -> str(handle.value)
                     self.mark_modified()
                     return cst.Call(
-                        func=cst.Name("format"),
-                        args=[
-                            cst.Arg(value=base),
-                            cst.Arg(value=cst.SimpleString("'b'"))
-                        ]
+                        func=cst.Name("str"),
+                        args=[cst.Arg(value=base)]
                     )
 
         return updated_node

--- a/examples/test_example.py
+++ b/examples/test_example.py
@@ -22,8 +22,8 @@ cocotb.start_soon(my_task())
 i = int(sig.value)
 
 # Old: b = sig.value.binstr
-# Expected: b = format(sig.value, 'b')
-b = format(sig.value, 'b')
+# Expected: b = str(sig.value)
+b = str(sig.value)
 
 # ========================
 # BinaryValue Transformation

--- a/tests/test_handle_transformer.py
+++ b/tests/test_handle_transformer.py
@@ -7,9 +7,9 @@ def test_integer_to_int():
     mod = parse_module(source).visit(HandleTransformer())
     assert mod.code.strip() == expected
 
-def test_binstr_to_format():
+def test_binstr_to_str():
     source = "b = sig.value.binstr"
-    expected = "b = format(sig.value, 'b')"
+    expected = "b = str(sig.value)"
     mod = parse_module(source).visit(HandleTransformer())
     assert mod.code.strip() == expected
 


### PR DESCRIPTION
## Summary

Fixes #5

`str()` is the preferred way to convert a `LogicArray` to a string — it is
also what the LogicArray and BinaryValue transformers already emit.
`format(handle.value, 'b')` requires an integer and fails on a `LogicArray`,
so the HandleTransformer now produces `str(handle.value)` instead.

## Changes

- `cocotb2_migrator/transformers/handle_transformer.py`
  - `handle.value.binstr` -> `str(handle.value)`
- `tests/test_handle_transformer.py`
  - Renamed `test_binstr_to_format` -> `test_binstr_to_str`, updated expectation
- `README.md` — updated Handle Value Access docs (section 3)
- `examples/test_example.py` — updated the binstr example

## Testing

- `pytest tests/test_handle_transformer.py` -> 4 passed
- Full suite: 60 passed (2 pre-existing, unrelated failures in
  `test_clock_transformer.py` already present on `main`)
- End-to-end migrator run confirmed:
  `dut.signal.value.binstr` -> `str(dut.signal.value)`

## Note

This builds on top of #4 (merged), which removed the invalid
`get_value()` / `raw_value` transformations in the same file.