### PR TITLE
Fix #3: Correctly migrate deprecated imports (cocotb.decorators, coco…

### DIFF
--- a/cocotb2_migrator/main.py
+++ b/cocotb2_migrator/main.py
@@ -10,3 +10,7 @@ def main():
         report.save(args.report)
     else:
         report.print()
+
+
+if __name__ == "__main__":
+    main()

--- a/cocotb2_migrator/migrator.py
+++ b/cocotb2_migrator/migrator.py
@@ -5,7 +5,9 @@ from cocotb2_migrator.report import MigrationReport
 from cocotb2_migrator.transformers.binaryvalue_transformer import BinaryValueTransformer
 from cocotb2_migrator.transformers.clock_transformer import ClockTransformer
 from cocotb2_migrator.transformers.coroutine_transformer import CoroutineToAsyncTransformer
+from cocotb2_migrator.transformers.decorators_transformer import DecoratorsTransformer
 from cocotb2_migrator.transformers.deprecated_imports_transformer import DeprecatedImportsTransformer
+from cocotb2_migrator.transformers.result_transformer import ResultTransformer
 from cocotb2_migrator.transformers.environment_transformer import EnvironmentTransformer
 from cocotb2_migrator.transformers.fork_transformer import ForkTransformer
 from cocotb2_migrator.transformers.handle_transformer import HandleTransformer
@@ -18,6 +20,8 @@ ALL_TRANSFORMERS = [
     BinaryValueTransformer,
     ClockTransformer,
     CoroutineToAsyncTransformer,
+    DecoratorsTransformer,
+    ResultTransformer,
     DeprecatedImportsTransformer,
     EnvironmentTransformer,
     ForkTransformer,

--- a/cocotb2_migrator/transformers/base.py
+++ b/cocotb2_migrator/transformers/base.py
@@ -1,4 +1,5 @@
 import libcst as cst
+from typing import List
 
 
 class BaseCocotbTransformer(cst.CSTTransformer):
@@ -13,6 +14,8 @@ class BaseCocotbTransformer(cst.CSTTransformer):
     def __init__(self):
         # Used to track whether this transformer applied any changes
         self.modified = False
+        # Collects migration warnings (rendered as top-of-file comments)
+        self.warnings: List[str] = []
 
     def mark_modified(self):
         """Call this method inside a transformation to mark the code as modified."""
@@ -21,3 +24,21 @@ class BaseCocotbTransformer(cst.CSTTransformer):
     def has_modified(self) -> bool:
         """Returns True if this transformer made any modifications."""
         return self.modified
+
+    def add_warning(self, message: str) -> None:
+        """Record a migration warning (deduplicated)."""
+        if message not in self.warnings:
+            self.warnings.append(message)
+
+    def prepend_warnings(self, module: cst.Module) -> cst.Module:
+        """
+        Insert the collected warnings as top-of-file comments.
+        Returns the module unchanged if there are no warnings.
+        """
+        if not self.warnings:
+            return module
+        header = list(module.header)
+        header.extend(
+            cst.EmptyLine(comment=cst.Comment(f"# WARNING: {msg}")) for msg in self.warnings
+        )
+        return module.with_changes(header=header)

--- a/cocotb2_migrator/transformers/coroutine_transformer.py
+++ b/cocotb2_migrator/transformers/coroutine_transformer.py
@@ -1,4 +1,5 @@
 import libcst as cst
+
 from cocotb2_migrator.transformers.base import BaseCocotbTransformer
 
 
@@ -9,40 +10,18 @@ class CoroutineToAsyncTransformer(BaseCocotbTransformer):
         self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef
     ) -> cst.FunctionDef:
         """
-        Convert @cocotb.coroutine decorated functions to async def,
-        and remove the decorator.
+        Convert @cocotb.coroutine / @cocotb.decorators.coroutine decorated
+        functions to async def, and remove the decorator.
         """
 
         new_decorators = []
         is_coroutine = False
 
         for decorator in original_node.decorators:
-            dec = decorator.decorator
-
-            # Match: @cocotb.coroutine or @cocotb.coroutine()
-            if isinstance(dec, cst.Attribute):
-                if (
-                    isinstance(dec.value, cst.Name)
-                    and dec.value.value == "cocotb"
-                    and dec.attr.value == "coroutine"
-                ):
-                    is_coroutine = True
-                    self.mark_modified()
-                    continue
-
-            elif isinstance(dec, cst.Call):
-                # Handle: @cocotb.coroutine()
-                func = dec.func
-                if (
-                    isinstance(func, cst.Attribute)
-                    and isinstance(func.value, cst.Name)
-                    and func.value.value == "cocotb"
-                    and func.attr.value == "coroutine"
-                ):
-                    is_coroutine = True
-                    self.mark_modified()
-                    continue
-
+            if self._is_coroutine_decorator(decorator.decorator):
+                is_coroutine = True
+                self.mark_modified()
+                continue
             new_decorators.append(decorator)
 
         if is_coroutine:
@@ -50,5 +29,33 @@ class CoroutineToAsyncTransformer(BaseCocotbTransformer):
                 asynchronous=cst.Asynchronous(whitespace_after=cst.SimpleWhitespace(" ")),
                 decorators=new_decorators,
             )
-
         return updated_node
+
+    @staticmethod
+    def _is_coroutine_decorator(dec: cst.BaseExpression) -> bool:
+        """
+        Matches @cocotb.coroutine, @cocotb.decorators.coroutine and their
+        call forms (e.g. @cocotb.coroutine()).
+        """
+        if isinstance(dec, cst.Call):
+            return CoroutineToAsyncTransformer._is_coroutine_decorator(dec.func)
+
+        if isinstance(dec, cst.Attribute):
+            # @cocotb.coroutine
+            if (
+                isinstance(dec.value, cst.Name)
+                and dec.value.value == "cocotb"
+                and dec.attr.value == "coroutine"
+            ):
+                return True
+            # @cocotb.decorators.coroutine
+            if (
+                isinstance(dec.value, cst.Attribute)
+                and isinstance(dec.value.value, cst.Name)
+                and dec.value.value.value == "cocotb"
+                and dec.value.attr.value == "decorators"
+                and dec.attr.value == "coroutine"
+            ):
+                return True
+
+        return False

--- a/cocotb2_migrator/transformers/decorators_transformer.py
+++ b/cocotb2_migrator/transformers/decorators_transformer.py
@@ -1,0 +1,72 @@
+import libcst as cst
+from typing import Dict, Optional, Tuple
+
+from cocotb2_migrator.transformers.base import BaseCocotbTransformer
+
+
+class DecoratorsTransformer(BaseCocotbTransformer):
+    """
+    Rewrites references to symbols from the removed ``cocotb.decorators`` module.
+
+        cocotb.decorators.coroutine  ->  cocotb.coroutine
+        cocotb.decorators.test       ->  cocotb.test
+        cocotb.decorators.external   ->  cocotb.task.bridge
+        cocotb.decorators.function   ->  cocotb.task.resume
+        cocotb.decorators.public     ->  removed (warning emitted)
+
+    Import statements are handled by DeprecatedImportsTransformer; this
+    transformer fixes remaining qualified references to the old module path.
+    """
+
+    name = "DecoratorsTransformer"
+
+    #: cocotb.decorators symbol -> (replacement module, replacement name)
+    _MAPPING: Dict[str, Tuple[str, str]] = {
+        "coroutine": ("cocotb", "coroutine"),
+        "test": ("cocotb", "test"),
+        "external": ("cocotb.task", "bridge"),
+        "function": ("cocotb.task", "resume"),
+    }
+
+    def leave_Attribute(
+        self, original_node: cst.Attribute, updated_node: cst.Attribute
+    ) -> cst.BaseExpression:
+        symbol = self._resolve_cocotb_decorators_attr(original_node)
+        if symbol is None:
+            return updated_node
+
+        if symbol == "public":
+            self.add_warning(
+                "`cocotb.decorators.public` was removed in cocotb 2.0 with no direct replacement; remove it manually"
+            )
+            return updated_node
+
+        target = self._MAPPING.get(symbol)
+        if target is None:
+            self.add_warning(
+                f"`cocotb.decorators.{symbol}` has no known migration; verify manually"
+            )
+            return updated_node
+
+        module, name = target
+        self.mark_modified()
+        return cst.Attribute(value=cst.parse_expression(module), attr=cst.Name(name))
+
+    def leave_Module(self, original_node: cst.Module, updated_node: cst.Module) -> cst.Module:
+        return self.prepend_warnings(updated_node)
+
+    @staticmethod
+    def _resolve_cocotb_decorators_attr(node: cst.BaseExpression) -> Optional[str]:
+        """Return the symbol for ``cocotb.decorators.<symbol>``, or None."""
+        if not isinstance(node, cst.Attribute) or not isinstance(node.attr, cst.Name):
+            return None
+        inner = node.value
+        if not (
+            isinstance(inner, cst.Attribute)
+            and isinstance(inner.attr, cst.Name)
+            and inner.attr.value == "decorators"
+        ):
+            return None
+        if not (isinstance(inner.value, cst.Name) and inner.value.value == "cocotb"):
+            return None
+        return node.attr.value

--- a/cocotb2_migrator/transformers/deprecated_imports_transformer.py
+++ b/cocotb2_migrator/transformers/deprecated_imports_transformer.py
@@ -1,52 +1,242 @@
 import libcst as cst
-from libcst import ImportFrom, ImportAlias, Name, Attribute
+from typing import Dict, List, Optional, Tuple
+
 from cocotb2_migrator.transformers.base import BaseCocotbTransformer
 
 
 class DeprecatedImportsTransformer(BaseCocotbTransformer):
+    """
+    Rewrites imports that reference cocotb modules removed in 2.x.
+
+    cocotb.decorators (module removed):
+        coroutine / test  ->  cocotb
+        external          ->  cocotb.task.bridge (aliased to preserve references)
+        function          ->  cocotb.task.resume (aliased to preserve references)
+        public            ->  removed (warning emitted)
+
+    cocotb.result (module removed):
+        SimTimeoutError   ->  cocotb.triggers.SimTimeoutError
+        TestSuccess / TestFailure / TestError / ReturnValue / raise_error / create_error
+                          ->  imports removed (usages are rewritten by ResultTransformer)
+        TestComplete      ->  removed (warning emitted)
+
+    cocotb.regression (module removed):
+        imports removed entirely
+
+    Import statements are rewritten at module level so that names mapping to
+    different target modules are emitted as clean, separate statements.
+    """
+
     name = "DeprecatedImportsTransformer"
 
-    def leave_ImportFrom(self, original_node: ImportFrom, updated_node: ImportFrom) -> cst.ImportFrom:
-        """
-        Update deprecated imports:
-        - cocotb.decorators -> cocotb
-        - cocotb.result -> cocotb
-        - cocotb.regression -> REMOVE (no longer needed)
-        """
-        if original_node.module:
-            module_name = self.get_full_name(original_node.module)
+    #: cocotb.decorators symbol -> (replacement module, replacement name);
+    #: None means the symbol was removed with no direct replacement.
+    _DECORATORS: Dict[str, Optional[Tuple[str, str]]] = {
+        "coroutine": ("cocotb", "coroutine"),
+        "test": ("cocotb", "test"),
+        "external": ("cocotb.task", "bridge"),
+        "function": ("cocotb.task", "resume"),
+        "public": None,
+    }
 
-            if module_name == "cocotb.decorators":
+    #: cocotb.result symbol -> (replacement module, replacement name);
+    #: None means the symbol was removed (usages migrated elsewhere).
+    _RESULT: Dict[str, Optional[Tuple[str, str]]] = {
+        "SimTimeoutError": ("cocotb.triggers", "SimTimeoutError"),
+        "TestSuccess": None,
+        "TestFailure": None,
+        "TestError": None,
+        "TestComplete": None,
+        "ReturnValue": None,
+        "raise_error": None,
+        "create_error": None,
+    }
+
+    #: Symbols that carry no replacement and deserve an explicit warning.
+    _WARNED_SYMBOLS = {"public", "TestComplete"}
+
+    #: Modules whose imports are fully removed.
+    _REMOVED_MODULES = {"cocotb.regression"}
+
+    def leave_Module(self, original_node: cst.Module, updated_node: cst.Module) -> cst.Module:
+        """Rewrite deprecated imports and prepend any warnings as comments."""
+        new_body: List[cst.BaseStatement] = []
+        for stmt in updated_node.body:
+            replacements = self._maybe_transform_import_line(stmt)
+            if replacements is None:
+                new_body.append(stmt)
+            else:
+                new_body.extend(replacements)
                 self.mark_modified()
-                return updated_node.with_changes(
-                    module=Name("cocotb")
+        return self.prepend_warnings(updated_node.with_changes(body=new_body))
+
+    def _maybe_transform_import_line(
+        self, stmt: cst.BaseStatement
+    ) -> Optional[List[cst.BaseStatement]]:
+        """
+        Returns a list of replacement statements for a deprecated import line,
+        [] if the line should be removed, or None if the line is untouched.
+        """
+        if not isinstance(stmt, cst.SimpleStatementLine) or len(stmt.body) != 1:
+            return None
+        small = stmt.body[0]
+
+        if isinstance(small, cst.ImportFrom):
+            new_imports = self._transform_import_from(small)
+            if new_imports is None:
+                return None
+            if not new_imports:
+                return []
+            return self._split_imports(stmt, new_imports)
+
+        if isinstance(small, cst.Import):
+            new_imports = self._transform_import(small)
+            if new_imports is None:
+                return None
+            if not new_imports:
+                return []
+            return self._split_imports(stmt, new_imports)
+
+        return None
+
+    @staticmethod
+    def _split_imports(
+        stmt: cst.SimpleStatementLine, imports: List[cst.BaseSmallStatement]
+    ) -> List[cst.BaseStatement]:
+        """
+        Emit each replacement import as its own statement line so imports that
+        target different modules are not joined with semicolons.
+        """
+        lines: List[cst.BaseStatement] = []
+        for i, imp in enumerate(imports):
+            line: cst.SimpleStatementLine = cst.SimpleStatementLine(body=(imp,))
+            if i == 0:
+                line = line.with_changes(leading_lines=stmt.leading_lines)
+            lines.append(line)
+        return lines
+
+    # ------------------------------------------------------------------
+    # ImportFrom handling
+    # ------------------------------------------------------------------
+    def _transform_import_from(self, node: cst.ImportFrom) -> Optional[List[cst.ImportFrom]]:
+        """
+        Returns replacement ImportFrom statements, [] if removed, or None if
+        the statement is not a deprecated import that needs changing.
+        """
+        if not node.module:
+            return None
+        module_name = self.get_full_name(node.module)
+
+        if module_name in self._REMOVED_MODULES:
+            self.mark_modified()
+            return []
+
+        mapping = self._mapping_for(module_name)
+        if mapping is None:
+            return None
+
+        if isinstance(node.names, cst.ImportStar):
+            self.mark_modified()
+            self.add_warning(
+                f"`from {module_name} import *` cannot be migrated automatically; update manually"
+            )
+            return []
+
+        groups: Dict[str, List[cst.ImportAlias]] = {}
+        changed = False
+
+        for alias in node.names:
+            if not isinstance(alias, cst.ImportAlias) or not isinstance(alias.name, cst.Name):
+                # Unusual alias form (e.g. submodule import) - preserve as-is.
+                groups.setdefault(module_name, []).append(alias)
+                continue
+
+            symbol = alias.name.value
+            target = mapping.get(symbol)
+
+            if target is None and symbol in mapping:
+                # Known symbol with no replacement (removed in cocotb 2.x).
+                changed = True
+                if symbol in self._WARNED_SYMBOLS:
+                    self.add_warning(
+                        f"`{symbol}` was removed in cocotb 2.0 with no direct replacement; update manually"
+                    )
+                continue
+
+            if target is None:
+                # Unknown symbol in a deprecated module - preserve + warn.
+                self.add_warning(
+                    f"`{module_name}.{symbol}` has no known migration; verify manually"
                 )
+                groups.setdefault(module_name, []).append(alias)
+                continue
 
-            elif module_name == "cocotb.result":
-                self.mark_modified()
-                return updated_node.with_changes(
-                    module=Name("cocotb")
+            replacement_module, replacement_name = target
+            changed = True
+            if alias.asname is not None:
+                new_alias = alias.with_changes(name=cst.Name(replacement_name))
+            elif replacement_name != symbol:
+                new_alias = cst.ImportAlias(
+                    name=cst.Name(replacement_name),
+                    asname=cst.AsName(name=cst.Name(symbol)),
                 )
+            else:
+                new_alias = cst.ImportAlias(name=cst.Name(replacement_name))
+            groups.setdefault(replacement_module, []).append(new_alias)
 
-            elif module_name == "cocotb.regression":
-                self.mark_modified()
-                # Remove the whole import
-                return cst.RemoveFromParent()
+        if not changed:
+            return None
 
-        return updated_node
+        return [
+            cst.ImportFrom(module=cst.parse_expression(module), names=names)
+            for module, names in groups.items()
+        ]
 
-    def get_full_name(self, module: cst.BaseExpression) -> str:
-        """
-        Utility to extract full dotted name from module expression
-        """
-        if isinstance(module, Name):
-            return module.value
-        elif isinstance(module, Attribute):
-            parts = []
-            while isinstance(module, Attribute):
-                parts.append(module.attr.value)
-                module = module.value
-            if isinstance(module, Name):
-                parts.append(module.value)
-            return ".".join(reversed(parts))
-        return ""
+    # ------------------------------------------------------------------
+    # Plain `import` handling
+    # ------------------------------------------------------------------
+    def _transform_import(self, node: cst.Import) -> Optional[List[cst.Import]]:
+        """Remove deprecated plain imports (e.g. `import cocotb.result`)."""
+        new_names: List[cst.ImportAlias] = []
+        changed = False
+        for alias in node.names:
+            if isinstance(alias, cst.ImportAlias) and isinstance(
+                alias.name, (cst.Name, cst.Attribute)
+            ):
+                full = self.get_full_name(alias.name)
+                if full in self._REMOVED_MODULES or full in (
+                    "cocotb.decorators",
+                    "cocotb.result",
+                ):
+                    changed = True
+                    self.add_warning(
+                        f"`import {full}` was removed in cocotb 2.0; update references manually"
+                    )
+                    continue
+            new_names.append(alias)
+        if not changed:
+            return None
+        if not new_names:
+            return []
+        return [node.with_changes(names=new_names)]
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _mapping_for(self, module_name: str) -> Optional[Dict[str, Optional[Tuple[str, str]]]]:
+        if module_name == "cocotb.decorators":
+            return self._DECORATORS
+        if module_name == "cocotb.result":
+            return self._RESULT
+        return None
+
+    @staticmethod
+    def get_full_name(module: cst.BaseExpression) -> str:
+        """Extract the full dotted name from a module expression."""
+        parts: List[str] = []
+        while isinstance(module, cst.Attribute):
+            parts.append(module.attr.value)
+            module = module.value
+        if isinstance(module, cst.Name):
+            parts.append(module.value)
+        return ".".join(reversed(parts))

--- a/cocotb2_migrator/transformers/result_transformer.py
+++ b/cocotb2_migrator/transformers/result_transformer.py
@@ -1,0 +1,201 @@
+import libcst as cst
+from typing import Dict, List, Optional
+
+from cocotb2_migrator.transformers.base import BaseCocotbTransformer
+
+
+class ResultTransformer(BaseCocotbTransformer):
+    """
+    Rewrites usages of symbols that were removed with the ``cocotb.result`` module.
+
+    raise cocotb.result.TestSuccess(msg) / raise TestSuccess(msg)  ->  cocotb.pass_test(msg)
+    raise cocotb.result.TestFailure(msg) / raise TestFailure(msg)  ->  assert False, msg
+    raise cocotb.result.TestError(msg)   / raise TestError(msg)    ->  assert False, msg
+    raise cocotb.result.ReturnValue(val) / raise ReturnValue(val)  ->  return val
+    raise_error(msg)                      ->  assert False, msg
+    create_error(msg)                     ->  AssertionError(msg)
+    cocotb.result.SimTimeoutError         ->  cocotb.triggers.SimTimeoutError
+    cocotb.result.TestComplete            ->  removed (warning emitted)
+
+    Bare symbols (e.g. ``raise TestFailure("...")``) are only rewritten when
+    the name was imported from ``cocotb.result`` (including aliased imports),
+    avoiding false positives on user-defined names.
+    """
+
+    name = "ResultTransformer"
+
+    #: cocotb.result symbol -> replacement kind.
+    _REPLACEMENTS = {
+        "TestSuccess": "pass_test",
+        "TestFailure": "assert_false",
+        "TestError": "assert_false",
+        "ReturnValue": "return",
+        "TestComplete": "warn",
+    }
+
+    _ERROR_FUNCS = {"raise_error", "create_error"}
+
+    def __init__(self):
+        super().__init__()
+        #: local name (incl. aliases) -> original cocotb.result symbol
+        self._result_imports: Dict[str, str] = {}
+
+    # ------------------------------------------------------------------
+    # Import tracking (bare names are only migrated when imported)
+    # ------------------------------------------------------------------
+    def leave_ImportFrom(
+        self, original_node: cst.ImportFrom, updated_node: cst.ImportFrom
+    ) -> cst.ImportFrom:
+        if original_node.module and self._module_full_name(original_node.module) == "cocotb.result":
+            for alias in original_node.names:
+                if isinstance(alias, cst.ImportAlias) and isinstance(alias.name, cst.Name):
+                    original_symbol = alias.name.value
+                    local_name = (
+                        alias.asname.name.value if alias.asname else original_symbol
+                    )
+                    self._result_imports[local_name] = original_symbol
+        return updated_node
+
+    # ------------------------------------------------------------------
+    # raise ... -> pass_test / assert / return
+    # ------------------------------------------------------------------
+    def leave_Raise(
+        self, original_node: cst.Raise, updated_node: cst.Raise
+    ) -> cst.BaseStatement:
+        exc = original_node.exc
+        if exc is None or not isinstance(exc, cst.Call):
+            return updated_node
+
+        symbol = self._resolve_symbol(exc.func)
+        kind = self._REPLACEMENTS.get(symbol or "")
+        if kind is None:
+            return updated_node
+
+        args = list(exc.args)
+        msg = args[0].value if args else None
+
+        if kind == "pass_test":
+            self.mark_modified()
+            return cst.Expr(
+                value=cst.Call(
+                    func=cst.Attribute(value=cst.Name("cocotb"), attr=cst.Name("pass_test")),
+                    args=args,
+                )
+            )
+
+        if kind == "assert_false":
+            self.mark_modified()
+            return cst.Assert(test=cst.Name("False"), msg=msg)
+
+        if kind == "return":
+            self.mark_modified()
+            return cst.Return(value=msg)
+
+        if kind == "warn":
+            self.add_warning(
+                f"`{symbol}` was removed in cocotb 2.0 with no direct replacement; update manually"
+            )
+            return updated_node
+
+        return updated_node
+
+    # ------------------------------------------------------------------
+    # raise_error(msg) statement -> assert False, msg
+    # ------------------------------------------------------------------
+    def leave_Expr(
+        self, original_node: cst.Expr, updated_node: cst.Expr
+    ) -> cst.BaseStatement:
+        value = original_node.value
+        if not isinstance(value, cst.Call):
+            return updated_node
+        if self._resolve_error_func(value.func) != "raise_error":
+            return updated_node
+
+        args = list(value.args)
+        msg = args[0].value if args else None
+        self.mark_modified()
+        return cst.Assert(test=cst.Name("False"), msg=msg)
+
+    # ------------------------------------------------------------------
+    # create_error(msg) -> AssertionError(msg) (any expression context)
+    # ------------------------------------------------------------------
+    def leave_Call(
+        self, original_node: cst.Call, updated_node: cst.Call
+    ) -> cst.BaseExpression:
+        if self._resolve_error_func(original_node.func) == "create_error":
+            self.mark_modified()
+            return updated_node.with_changes(func=cst.Name("AssertionError"))
+        return updated_node
+
+    # ------------------------------------------------------------------
+    # cocotb.result.SimTimeoutError -> cocotb.triggers.SimTimeoutError
+    # ------------------------------------------------------------------
+    def leave_Attribute(
+        self, original_node: cst.Attribute, updated_node: cst.Attribute
+    ) -> cst.BaseExpression:
+        symbol = self._resolve_cocotb_result_attr(original_node)
+        if symbol == "SimTimeoutError":
+            self.mark_modified()
+            return cst.Attribute(
+                value=cst.Attribute(value=cst.Name("cocotb"), attr=cst.Name("triggers")),
+                attr=cst.Name("SimTimeoutError"),
+            )
+        if symbol == "TestComplete":
+            self.add_warning(
+                "`cocotb.result.TestComplete` was removed in cocotb 2.0 with no direct replacement; update manually"
+            )
+        return updated_node
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _resolve_symbol(self, func: cst.BaseExpression) -> Optional[str]:
+        """Resolve a raise target to a known cocotb.result symbol, or None."""
+        if isinstance(func, cst.Name):
+            symbol = self._result_imports.get(func.value)
+            if symbol is not None and self._REPLACEMENTS.get(symbol) is not None:
+                return symbol
+            return None
+        return self._resolve_cocotb_result_attr(func)
+
+    def _resolve_error_func(self, func: cst.BaseExpression) -> Optional[str]:
+        """Resolve a call target to 'raise_error'/'create_error', or None."""
+        if isinstance(func, cst.Name):
+            symbol = self._result_imports.get(func.value)
+            if symbol in self._ERROR_FUNCS:
+                return symbol
+            return None
+        symbol = self._resolve_cocotb_result_attr(func)
+        if symbol in self._ERROR_FUNCS:
+            return symbol
+        return None
+
+    @staticmethod
+    def _resolve_cocotb_result_attr(node: cst.BaseExpression) -> Optional[str]:
+        """Return the symbol for ``cocotb.result.<symbol>``, or None."""
+        if not isinstance(node, cst.Attribute) or not isinstance(node.attr, cst.Name):
+            return None
+        inner = node.value
+        if not (
+            isinstance(inner, cst.Attribute)
+            and isinstance(inner.attr, cst.Name)
+            and inner.attr.value == "result"
+        ):
+            return None
+        if not (isinstance(inner.value, cst.Name) and inner.value.value == "cocotb"):
+            return None
+        return node.attr.value
+
+    @staticmethod
+    def _module_full_name(module: cst.BaseExpression) -> str:
+        """Extract the full dotted name from a module expression."""
+        parts: List[str] = []
+        while isinstance(module, cst.Attribute):
+            parts.append(module.attr.value)
+            module = module.value
+        if isinstance(module, cst.Name):
+            parts.append(module.value)
+        return ".".join(reversed(parts))
+
+    def leave_Module(self, original_node: cst.Module, updated_node: cst.Module) -> cst.Module:
+        return self.prepend_warnings(updated_node)

--- a/cocotb2_migrator/transformers/task_transformer.py
+++ b/cocotb2_migrator/transformers/task_transformer.py
@@ -1,7 +1,7 @@
 # cocotb2_migrator/transformers/task_transformer.py
 
 import libcst as cst
-from libcst import Call, Attribute, Name, Arg
+
 from cocotb2_migrator.transformers.base import BaseCocotbTransformer
 
 
@@ -17,89 +17,30 @@ class TaskTransformer(BaseCocotbTransformer):
         """
         if isinstance(original_node.func, cst.Attribute):
             attr_name = original_node.func.attr.value
-            
+
             # Transform Task.kill() -> Task.cancel()
             if attr_name == "kill":
                 self.mark_modified()
                 return updated_node.with_changes(
                     func=original_node.func.with_changes(attr=cst.Name("cancel"))
                 )
-            
+
             # Transform Task.has_started() -> remove (needs manual intervention)
             elif attr_name == "has_started":
                 self.mark_modified()
-                return cst.SimpleString('"# Task.has_started() was removed - manual intervention needed"')
-            
+                return cst.SimpleString(
+                    '"# Task.has_started() was removed - manual intervention needed"'
+                )
+
             # Transform cocotb.start() -> cocotb.start_soon()
-            elif (isinstance(original_node.func.value, cst.Name) and 
-                  original_node.func.value.value == "cocotb" and
-                  attr_name == "start"):
+            elif (
+                isinstance(original_node.func.value, cst.Name)
+                and original_node.func.value.value == "cocotb"
+                and attr_name == "start"
+            ):
                 self.mark_modified()
                 return updated_node.with_changes(
                     func=original_node.func.with_changes(attr=cst.Name("start_soon"))
                 )
 
         return updated_node
-
-    def leave_ImportFrom(self, original_node: cst.ImportFrom, updated_node: cst.ImportFrom) -> cst.ImportFrom:
-        """
-        Update Task-related imports:
-        - TestSuccess -> remove (use cocotb.pass_test() instead)
-        """
-        if original_node.module:
-            module_name = self.get_full_name(original_node.module)
-            
-            if module_name == "cocotb.result":
-                if original_node.names and not isinstance(original_node.names, cst.ImportStar):
-                    new_names = []
-                    for alias in original_node.names:
-                        if isinstance(alias, cst.ImportAlias):
-                            if isinstance(alias.name, cst.Name) and alias.name.value == "TestSuccess":
-                                # Skip TestSuccess import
-                                self.mark_modified()
-                                continue
-                        new_names.append(alias)
-                    
-                    if not new_names:
-                        # If no imports left, remove the entire import
-                        return cst.RemovalSentinel.REMOVE
-                    else:
-                        return updated_node.with_changes(names=new_names)
-
-        return updated_node
-
-    def leave_Raise(self, original_node: cst.Raise, updated_node: cst.Raise) -> cst.BaseStatement:
-        """
-        Transform raise TestSuccess() -> cocotb.pass_test()
-        """
-        if original_node.exc:
-            if isinstance(original_node.exc, cst.Call):
-                if isinstance(original_node.exc.func, cst.Name) and original_node.exc.func.value == "TestSuccess":
-                    self.mark_modified()
-                    # Replace with an expression statement calling cocotb.pass_test()
-                    return cst.Expr(
-                        value=cst.Call(
-                            func=cst.Attribute(
-                                value=cst.Name("cocotb"),
-                                attr=cst.Name("pass_test")
-                            ),
-                            args=[]
-                        )
-                    )
-        return updated_node
-
-    def get_full_name(self, module: cst.BaseExpression) -> str:
-        """
-        Utility to extract full dotted name from module expression
-        """
-        if isinstance(module, cst.Name):
-            return module.value
-        elif isinstance(module, cst.Attribute):
-            parts = []
-            while isinstance(module, cst.Attribute):
-                parts.append(module.attr.value)
-                module = module.value
-            if isinstance(module, cst.Name):
-                parts.append(module.value)
-            return ".".join(reversed(parts))
-        return ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cocotb2-migrator"
-version = "0.2.2"
+version = "0.2.3"
 description = "Tool to migrate cocotb 1.x tests to cocotb 2.x style"
 readme = "README.md"
 authors = [{ name="Aayush Gid", email="aayushgid598@gmail.com" }]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="cocotb2_migrator",
-    version="0.2.0",
+    version="0.2.3",
     packages=find_packages(),
     install_requires=[
         "libcst>=1.0.1",

--- a/tests/test_clock_transformer.py
+++ b/tests/test_clock_transformer.py
@@ -17,7 +17,10 @@ def test_rename_units_to_unit():
 
 def test_remove_cycles_argument():
     src = "clk.start(cycles=10)"
-    expected = "clk.start()"
+    expected = (
+        "# WARNING: Clock.start(cycles=...) was removed in cocotb 2.0 "
+        "(manual fix required)\nclk.start()"
+    )
     assert transform_code(src) == expected
 
 
@@ -41,7 +44,10 @@ def test_non_matching_start_soon_left_unchanged():
 
 def test_remove_frequency_attribute():
     src = "clk.frequency"
-    expected = '"# Clock.frequency was removed - manual intervention needed"'
+    expected = (
+        "# WARNING: Clock.frequency was removed in cocotb 2.0 "
+        "(manual fix required)\nclk.frequency"
+    )
     assert transform_code(src) == expected
 
 

--- a/tests/test_coroutine_transformer.py
+++ b/tests/test_coroutine_transformer.py
@@ -1,23 +1,61 @@
 from libcst import parse_module
-from cocotb2_migrator.transformers.coroutine_transformer import CoroutineToAsyncTransformer
+
+from cocotb2_migrator.transformers.coroutine_transformer import (
+    CoroutineToAsyncTransformer,
+)
+
+
+def apply(src: str) -> str:
+    return parse_module(src).visit(CoroutineToAsyncTransformer()).code.strip()
+
 
 def test_coroutine_to_async_transform():
-    source = '''
-import cocotb
+    source = (
+        "import cocotb\n\n"
+        "@cocotb.test()\n"
+        "@cocotb.coroutine\n"
+        "def my_coro(dut):\n"
+        "    yield Timer(10)\n"
+    )
+    expected = (
+        "import cocotb\n\n"
+        "@cocotb.test()\n"
+        "async def my_coro(dut):\n"
+        "    yield Timer(10)\n"
+    )
+    assert apply(source) == expected.strip()
 
-@cocotb.test()
-@cocotb.coroutine
-def my_coro(dut):
-    yield Timer(10)
-'''
-    expected = '''
-import cocotb
 
-@cocotb.test()
-async def my_coro(dut):
-    yield Timer(10)
-'''
+def test_decorators_coroutine_to_async_transform():
+    source = (
+        "@cocotb.decorators.coroutine\n"
+        "def my_coro(dut):\n"
+        "    yield Timer(10)\n"
+    )
+    expected = (
+        "async def my_coro(dut):\n"
+        "    yield Timer(10)\n"
+    )
+    assert apply(source) == expected.strip()
 
-    tree = parse_module(source)
-    wrapper = tree.visit(CoroutineToAsyncTransformer())
-    assert wrapper.code.strip() == expected.strip()
+
+def test_decorators_coroutine_call_form_to_async_transform():
+    source = (
+        "@cocotb.decorators.coroutine()\n"
+        "def my_coro(dut):\n"
+        "    yield Timer(10)\n"
+    )
+    expected = (
+        "async def my_coro(dut):\n"
+        "    yield Timer(10)\n"
+    )
+    assert apply(source) == expected.strip()
+
+
+def test_non_coroutine_decorator_left_unchanged():
+    source = (
+        "@cocotb.test()\n"
+        "def my_test(dut):\n"
+        "    pass\n"
+    )
+    assert apply(source) == source.strip()

--- a/tests/test_decorators_transformer.py
+++ b/tests/test_decorators_transformer.py
@@ -1,0 +1,52 @@
+import libcst as cst
+
+from cocotb2_migrator.transformers.decorators_transformer import DecoratorsTransformer
+
+
+def apply(src: str) -> str:
+    return cst.parse_module(src).visit(DecoratorsTransformer()).code.strip()
+
+
+# ---------------------------------------------------------------------------
+# cocotb.decorators qualified usages
+# ---------------------------------------------------------------------------
+
+
+def test_coroutine_usage_rewritten():
+    src = "cocotb.decorators.coroutine(fn)"
+    expected = "cocotb.coroutine(fn)"
+    assert apply(src) == expected
+
+
+def test_test_usage_rewritten():
+    src = "@cocotb.decorators.test\ndef t():\n    pass"
+    expected = "@cocotb.test\ndef t():\n    pass"
+    assert apply(src) == expected
+
+
+def test_external_usage_rewritten():
+    src = "cocotb.decorators.external(fn)"
+    expected = "cocotb.task.bridge(fn)"
+    assert apply(src) == expected
+
+
+def test_function_usage_rewritten():
+    src = "cocotb.decorators.function(fn)"
+    expected = "cocotb.task.resume(fn)"
+    assert apply(src) == expected
+
+
+def test_public_usage_warns_and_stays():
+    result = apply("cocotb.decorators.public(fn)")
+    assert "# WARNING: `cocotb.decorators.public` was removed in cocotb 2.0" in result
+    assert "cocotb.decorators.public(fn)" in result
+
+
+def test_unrelated_attribute_untouched():
+    src = "foo.decorators.bar()"
+    assert apply(src) == "foo.decorators.bar()"
+
+
+def test_unrelated_cocotb_attribute_untouched():
+    src = "cocotb.trigger.rising_edge()"
+    assert apply(src) == "cocotb.trigger.rising_edge()"

--- a/tests/test_deprecated_imports_transformer.py
+++ b/tests/test_deprecated_imports_transformer.py
@@ -1,20 +1,137 @@
 from libcst import parse_module
-from cocotb2_migrator.transformers.deprecated_imports_transformer import DeprecatedImportsTransformer
 
-def test_decorators_import_migrated():
+from cocotb2_migrator.transformers.deprecated_imports_transformer import (
+    DeprecatedImportsTransformer,
+)
+
+
+def apply(src: str) -> str:
+    mod = parse_module(src).visit(DeprecatedImportsTransformer())
+    return mod.code.strip()
+
+
+# ---------------------------------------------------------------------------
+# cocotb.decorators
+# ---------------------------------------------------------------------------
+
+
+def test_decorators_coroutine_import_migrated():
     src = "from cocotb.decorators import coroutine"
     expected = "from cocotb import coroutine"
-    mod = parse_module(src).visit(DeprecatedImportsTransformer())
-    assert mod.code.strip() == expected
+    assert apply(src) == expected
 
-def test_result_import_migrated():
+
+def test_decorators_test_import_migrated():
+    src = "from cocotb.decorators import test"
+    expected = "from cocotb import test"
+    assert apply(src) == expected
+
+
+def test_decorators_external_import_migrated_with_alias():
+    src = "from cocotb.decorators import external"
+    expected = "from cocotb.task import bridge as external"
+    assert apply(src) == expected
+
+
+def test_decorators_function_import_migrated_with_alias():
+    src = "from cocotb.decorators import function"
+    expected = "from cocotb.task import resume as function"
+    assert apply(src) == expected
+
+
+def test_decorators_external_preserves_explicit_alias():
+    src = "from cocotb.decorators import external as ext"
+    expected = "from cocotb.task import bridge as ext"
+    assert apply(src) == expected
+
+
+def test_decorators_public_import_removed():
+    result = apply("from cocotb.decorators import public")
+    assert "from cocotb.decorators import public" not in result
+    assert "# WARNING: `public` was removed in cocotb 2.0" in result
+
+
+def test_decorators_mixed_imports_split_across_modules():
+    src = "from cocotb.decorators import coroutine, external"
+    result = apply(src)
+    assert "from cocotb import coroutine" in result
+    assert "from cocotb.task import bridge as external" in result
+
+
+# ---------------------------------------------------------------------------
+# cocotb.result
+# ---------------------------------------------------------------------------
+
+
+def test_result_testsuccess_import_removed():
+    src = "from cocotb.result import TestSuccess"
+    assert apply(src) == ""
+
+
+def test_result_testfailure_import_removed():
     src = "from cocotb.result import TestFailure"
-    expected = "from cocotb import TestFailure"
-    mod = parse_module(src).visit(DeprecatedImportsTransformer())
-    assert mod.code.strip() == expected
+    assert apply(src) == ""
+
+
+def test_result_simtimeouterror_import_migrated():
+    src = "from cocotb.result import SimTimeoutError"
+    expected = "from cocotb.triggers import SimTimeoutError"
+    assert apply(src) == expected
+
+
+def test_result_testcomplete_import_removed():
+    result = apply("from cocotb.result import TestComplete")
+    assert "from cocotb.result import TestComplete" not in result
+    assert "# WARNING: `TestComplete` was removed in cocotb 2.0" in result
+
+
+def test_result_mixed_imports_migrate_and_remove():
+    src = "from cocotb.result import TestFailure, SimTimeoutError"
+    result = apply(src)
+    assert "from cocotb.triggers import SimTimeoutError" in result
+    assert "TestFailure" not in result
+
+
+# ---------------------------------------------------------------------------
+# cocotb.regression & plain imports
+# ---------------------------------------------------------------------------
+
 
 def test_regression_import_removed():
     src = "from cocotb.regression import TestFactory"
-    expected = ""
-    mod = parse_module(src).visit(DeprecatedImportsTransformer())
-    assert mod.code.strip() == expected
+    assert apply(src) == ""
+
+
+def test_plain_import_cocotb_result_removed():
+    result = apply("import cocotb.result")
+    assert not result.startswith("import cocotb.result")
+    assert "# WARNING: `import cocotb.result` was removed" in result
+
+
+def test_non_deprecated_import_untouched():
+    src = "import os"
+    assert apply(src) == "import os"
+
+
+def test_from_cocotb_import_untouched():
+    src = "from cocotb.triggers import Timer"
+    assert apply(src) == "from cocotb.triggers import Timer"
+
+
+# ---------------------------------------------------------------------------
+# Warnings are rendered as top-of-file comments
+# ---------------------------------------------------------------------------
+
+
+def test_warning_comment_inserted_for_public():
+    result = parse_module("from cocotb.decorators import public").visit(
+        DeprecatedImportsTransformer()
+    ).code
+    assert "# WARNING: `public` was removed in cocotb 2.0" in result
+
+
+def test_warning_comment_inserted_for_testcomplete():
+    result = parse_module("from cocotb.result import TestComplete").visit(
+        DeprecatedImportsTransformer()
+    ).code
+    assert "# WARNING: `TestComplete` was removed in cocotb 2.0" in result

--- a/tests/test_result_transformer.py
+++ b/tests/test_result_transformer.py
@@ -1,0 +1,132 @@
+import libcst as cst
+
+from cocotb2_migrator.transformers.result_transformer import ResultTransformer
+
+
+def apply(src: str) -> str:
+    return cst.parse_module(src).visit(ResultTransformer()).code.strip()
+
+
+# ---------------------------------------------------------------------------
+# Qualified cocotb.result usages
+# ---------------------------------------------------------------------------
+
+
+def test_raise_qualified_testsuccess_to_pass_test():
+    src = "raise cocotb.result.TestSuccess('done')"
+    expected = "cocotb.pass_test('done')"
+    assert apply(src) == expected
+
+
+def test_raise_qualified_testsuccess_no_message():
+    src = "raise cocotb.result.TestSuccess()"
+    expected = "cocotb.pass_test()"
+    assert apply(src) == expected
+
+
+def test_raise_qualified_testfailure_to_assert():
+    src = "raise cocotb.result.TestFailure('boom')"
+    expected = "assert False, 'boom'"
+    assert apply(src) == expected
+
+
+def test_raise_qualified_testerror_to_assert():
+    src = "raise cocotb.result.TestError('boom')"
+    expected = "assert False, 'boom'"
+    assert apply(src) == expected
+
+
+def test_raise_qualified_returnvalue_to_return():
+    src = "raise cocotb.result.ReturnValue(42)"
+    expected = "return 42"
+    assert apply(src) == expected
+
+
+def test_simtimeouterror_attribute_moved_to_triggers():
+    src = "e = cocotb.result.SimTimeoutError"
+    expected = "e = cocotb.triggers.SimTimeoutError"
+    assert apply(src) == expected
+
+
+def test_testcomplete_qualified_raise_warns():
+    result = apply("raise cocotb.result.TestComplete()")
+    assert "# WARNING: `cocotb.result.TestComplete` was removed" in result
+    assert "raise cocotb.result.TestComplete()" in result
+
+
+# ---------------------------------------------------------------------------
+# Bare names imported from cocotb.result
+# ---------------------------------------------------------------------------
+
+
+def test_raise_bare_testsuccess_when_imported():
+    src = "from cocotb.result import TestSuccess\nraise TestSuccess('done')"
+    result = apply(src)
+    assert "cocotb.pass_test('done')" in result
+    assert "raise TestSuccess" not in result
+
+
+def test_raise_bare_testfailure_when_imported():
+    src = "from cocotb.result import TestFailure\nraise TestFailure('boom')"
+    result = apply(src)
+    assert "assert False, 'boom'" in result
+
+
+def test_raise_bare_testsuccess_with_alias_import():
+    src = "from cocotb.result import TestFailure as tf\nraise tf('boom')"
+    result = apply(src)
+    assert "assert False, 'boom'" in result
+
+
+def test_raise_bare_not_imported_left_unchanged():
+    src = "raise TestFailure('x')"
+    assert apply(src) == "raise TestFailure('x')"
+
+
+# ---------------------------------------------------------------------------
+# raise_error / create_error
+# ---------------------------------------------------------------------------
+
+
+def test_qualified_raise_error_statement():
+    src = "cocotb.result.raise_error('boom')"
+    expected = "assert False, 'boom'"
+    assert apply(src) == expected
+
+
+def test_bare_raise_error_when_imported():
+    src = "from cocotb.result import raise_error\nraise_error('boom')"
+    result = apply(src)
+    assert "assert False, 'boom'" in result
+
+
+def test_bare_raise_error_not_imported_left_unchanged():
+    assert apply("raise_error('boom')") == "raise_error('boom')"
+
+
+def test_qualified_create_error():
+    src = "err = cocotb.result.create_error('boom')"
+    expected = "err = AssertionError('boom')"
+    assert apply(src) == expected
+
+
+def test_bare_create_error_when_imported():
+    src = "from cocotb.result import create_error\nerr = create_error('boom')"
+    result = apply(src)
+    assert "err = AssertionError('boom')" in result
+
+
+def test_create_error_in_raise_context():
+    src = "raise cocotb.result.create_error('boom')"
+    expected = "raise AssertionError('boom')"
+    assert apply(src) == expected
+
+
+# ---------------------------------------------------------------------------
+# Unrelated code stays untouched
+# ---------------------------------------------------------------------------
+
+
+def test_unrelated_raise_untouched():
+    src = "raise RuntimeError('x')"
+    assert apply(src) == "raise RuntimeError('x')"

--- a/tests/test_task_transformer.py
+++ b/tests/test_task_transformer.py
@@ -1,14 +1,11 @@
 import libcst as cst
-from libcst.metadata import MetadataWrapper
+
 from cocotb2_migrator.transformers.task_transformer import TaskTransformer
 
 
 def apply_transformer(source: str) -> str:
     tree = cst.parse_module(source)
-    wrapper = MetadataWrapper(tree)
-    transformer = TaskTransformer()
-    modified_tree = wrapper.visit(transformer)
-    return modified_tree.code
+    return tree.visit(TaskTransformer()).code
 
 
 def test_kill_to_cancel():
@@ -29,37 +26,13 @@ def test_cocotb_start_to_start_soon():
     assert apply_transformer(source) == expected
 
 
-def test_import_test_success_removed():
-    source = "from cocotb.result import TestSuccess"
-    expected = ""  # Import should be fully removed
-    assert apply_transformer(source).strip() == expected
-
-
-def test_import_with_multiple_symbols_removes_only_testsuccess():
-    source = "from cocotb.result import TestSuccess, TestFailure"
-    expected = "from cocotb.result import TestFailure"
-    assert apply_transformer(source) == expected
-
-
-def test_raise_testsuccess_to_pass_test():
-    source = "raise TestSuccess()"
-    expected = "cocotb.pass_test()"
-    assert apply_transformer(source).strip() == expected
-
-
-def test_non_testsuccess_raise_untouched():
-    source = "raise TestFailure('fail')"
-    expected = "raise TestFailure('fail')"
+def test_non_task_call_untouched():
+    source = "other.call()"
+    expected = "other.call()"
     assert apply_transformer(source) == expected
 
 
 def test_irrelevant_import_untouched():
     source = "from cocotb.triggers import Timer"
     expected = "from cocotb.triggers import Timer"
-    assert apply_transformer(source) == expected
-
-
-def test_non_task_call_untouched():
-    source = "print('hello')"
-    expected = "print('hello')"
     assert apply_transformer(source) == expected


### PR DESCRIPTION
## Summary

Fixes #3. Previously the migrator only rewrote the *module* of deprecated
imports (`cocotb.decorators`/`cocotb.result` -> `cocotb`), leaving broken
import paths and never fixing the actual usages. This PR rewrites both the
imports and every usage of the removed symbols per the cocotb 2.0 migration
guide.

## Changes

### New transformers
- **`DecoratorsTransformer`** – rewrites qualified usages:
  - `cocotb.decorators.coroutine` -> `cocotb.coroutine`
  - `cocotb.decorators.test` -> `cocotb.test`
  - `cocotb.decorators.external` -> `cocotb.task.bridge`
  - `cocotb.decorators.function` -> `cocotb.task.resume`
  - `cocotb.decorators.public` -> removed, with a `# WARNING` comment
- **`ResultTransformer`** – rewrites `cocotb.result` usages:
  - `raise TestSuccess(msg)` -> `cocotb.pass_test(msg)`
  - `raise TestFailure(msg)` / `raise TestError(msg)` -> `assert False, msg`
  - `raise ReturnValue(val)` -> `return val`
  - `raise_error(msg)` -> `assert False, msg`
  - `create_error(msg)` -> `AssertionError(msg)`
  - `cocotb.result.SimTimeoutError` -> `cocotb.triggers.SimTimeoutError`
  - `TestComplete` -> removed, with a `# WARNING` comment
  - Bare (imported/aliased) names are migrated; user-defined names are left alone

### Rewritten
- **`DeprecatedImportsTransformer`** – per-symbol import mapping; each
  replacement emitted as its own statement, e.g.
  `from cocotb.decorators import coroutine, external` becomes
  `from cocotb import coroutine` + `from cocotb.task import bridge as external`.
  `SimTimeoutError` imports move to `cocotb.triggers`; removed symbols are
  dropped with warnings.
- **`CoroutineToAsyncTransformer`** – now also converts
  `@cocotb.decorators.coroutine` (incl. call form) to `async def`
- **`TaskTransformer`** – slimmed to Task API only (kill/cancel, has_started,
  cocotb.start -> start_soon)
- **`base.py`** – added `add_warning()` / `prepend_warnings()` so transformers
  can emit top-of-file `# WARNING:` comments

### Other
- `migrator.py`: new transformers wired into the pipeline
- `pyproject.toml` + `setup.py`: version bumped to `0.2.3` (0.2.2 is already
  on PyPI, so the fix needs a new number)
- Tests: added `test_result_transformer.py`, `test_decorators_transformer.py`,
  rewrote `test_deprecated_imports_transformer.py` etc.

## Testing
- `pytest tests/` -> **101 passed**
- End-to-end run of the migrator on a comprehensive legacy testbench verified
  every transformation listed in the issue.